### PR TITLE
Small Fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,100 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.{cs,razor}]
+indent_style = tab
+indent_size = 4
+tab_size = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = true
+
+
+#### C# Coding Conventions ####
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_pattern_matching = true:silent
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Code-block preferences
+csharp_prefer_braces = true:silent
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:silent
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = no_change
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = true
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = true
+csharp_space_between_parentheses = control_flow_statements
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true

--- a/IconifyPanel.cs
+++ b/IconifyPanel.cs
@@ -17,6 +17,9 @@ public class IconifyPanel : Panel
 		get => _icon;
 		set
 		{
+			if (_icon == value)
+				return;
+
 			_icon = value;
 			_dirty = true;
 		}

--- a/IconifyPanel.cs
+++ b/IconifyPanel.cs
@@ -134,7 +134,7 @@ public class IconifyPanel : Panel
 		{
 			var basePath = task.Result;
 			if (string.IsNullOrEmpty(basePath))
-                return;
+				return;
 
 			Log.Info($"Fetched {basePath}");
 

--- a/IconifyPanel.cs
+++ b/IconifyPanel.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Sandbox.UI;
 
-[Alias("iconify")]
+[Alias( "iconify" )]
 public class IconifyPanel : Panel
 {
 	private Texture _svgTexture;
@@ -17,7 +17,7 @@ public class IconifyPanel : Panel
 		get => _icon;
 		set
 		{
-			if (_icon == value)
+			if ( _icon == value )
 				return;
 
 			_icon = value;
@@ -27,7 +27,7 @@ public class IconifyPanel : Panel
 
 	public IconifyPanel()
 	{
-		StyleSheet.Parse("""
+		StyleSheet.Parse( """
 		IconifyPanel, iconify {
 			height: 16px;
 			aspect-ratio: 1;
@@ -42,18 +42,18 @@ public class IconifyPanel : Panel
 		IconifyPanel:last-child, iconify:last-child {
 		    padding-right: 0;
 		}
-		""");
+		""" );
 	}
 
-	private (string Pack, string Name) ParseIcon(string icon)
+	private (string Pack, string Name) ParseIcon( string icon )
 	{
-		if (!icon.Contains(':'))
-			throw new ArgumentException("_name must be in the format 'pack:name'");
+		if ( !icon.Contains( ':' ) )
+			throw new ArgumentException( "_name must be in the format 'pack:name'" );
 
-		var splitName = icon.Split(':', StringSplitOptions.RemoveEmptyEntries);
+		var splitName = icon.Split( ':', StringSplitOptions.RemoveEmptyEntries );
 
-		if (splitName.Length != 2)
-			throw new ArgumentException("_name must be in the format 'pack:name'");
+		if ( splitName.Length != 2 )
+			throw new ArgumentException( "_name must be in the format 'pack:name'" );
 
 		var pack = splitName[0];
 		var name = splitName[1];
@@ -61,62 +61,62 @@ public class IconifyPanel : Panel
 		return (pack, name);
 	}
 
-	protected override void OnAfterTreeRender(bool firstTime)
+	protected override void OnAfterTreeRender( bool firstTime )
 	{
 		SetIcon();
 	}
 
-	public override void OnLayout(ref Rect layoutRect)
+	public override void OnLayout( ref Rect layoutRect )
 	{
 		_dirty = true;
 	}
 
-	public override void SetProperty(string name, string value)
+	public override void SetProperty( string name, string value )
 	{
-		base.SetProperty(name, value);
+		base.SetProperty( name, value );
 
-		if (name.Equals("icon", StringComparison.OrdinalIgnoreCase))
+		if ( name.Equals( "icon", StringComparison.OrdinalIgnoreCase ) )
 			Icon = value;
 	}
 
-	public override void DrawBackground(ref RenderState state)
+	public override void DrawBackground( ref RenderState state )
 	{
-		base.DrawBackground(ref state);
+		base.DrawBackground( ref state );
 
-		Graphics.Attributes.Set("LayerMat", Matrix.Identity);
-		Graphics.Attributes.Set("Texture", _svgTexture);
-		Graphics.Attributes.SetCombo("D_BLENDMODE", BlendMode.Normal);
-		Graphics.DrawQuad(Box.Rect, Material.UI.Basic, Color.White);
+		Graphics.Attributes.Set( "LayerMat", Matrix.Identity );
+		Graphics.Attributes.Set( "Texture", _svgTexture );
+		Graphics.Attributes.SetCombo( "D_BLENDMODE", BlendMode.Normal );
+		Graphics.DrawQuad( Box.Rect, Material.UI.Basic, Color.White );
 	}
 
 	/// <summary>
 	/// Fetches the icon - if it doesn't exist on disk, it will fetch it for you.
 	/// </summary>
-	private async Task<string> FetchIconAsync(string iconPath)
+	private async Task<string> FetchIconAsync( string iconPath )
 	{
-		var (pack, name) = ParseIcon(iconPath);
+		var (pack, name) = ParseIcon( iconPath );
 		var localPath = $"iconify/{pack}/{name}.svg";
 
-		if (!FileSystem.Data.FileExists(localPath))
+		if ( !FileSystem.Data.FileExists( localPath ) )
 		{
-			Log.Info($"Cache miss for icon '{iconPath}', fetching from API...");
+			Log.Info( $"Cache miss for icon '{iconPath}', fetching from API..." );
 
-			var directory = Path.GetDirectoryName(localPath);
-			FileSystem.Data.CreateDirectory(directory);
+			var directory = Path.GetDirectoryName( localPath );
+			FileSystem.Data.CreateDirectory( directory );
 
 			var remotePath = $"https://api.iconify.design/{pack}/{name}.svg";
-			var response = await Http.RequestAsync("GET", remotePath);
+			var response = await Http.RequestAsync( "GET", remotePath );
 			var iconContents = await response.Content.ReadAsStringAsync();
-			iconContents = iconContents.Replace(" width=\"1em\" height=\"1em\"", ""); // HACK
+			iconContents = iconContents.Replace( " width=\"1em\" height=\"1em\"", "" ); // HACK
 
 			// this API doesn't actually return a 404 status code, so check the document for '404' itself...
-			if (iconContents == "404")
+			if ( iconContents == "404" )
 			{
-				Log.Error($"Failed to fetch icon {iconPath}");
+				Log.Error( $"Failed to fetch icon {iconPath}" );
 				return "";
 			}
 
-			FileSystem.Data.WriteAllText(localPath, iconContents);
+			FileSystem.Data.WriteAllText( localPath, iconContents );
 		}
 
 		return localPath;
@@ -124,19 +124,19 @@ public class IconifyPanel : Panel
 
 	private void SetIcon()
 	{
-		if (!_dirty)
+		if ( !_dirty )
 			return;
 
 		_dirty = false;
 		_svgTexture = Texture.White;
 
-		FetchIconAsync(Icon).ContinueWith(task =>
+		FetchIconAsync( Icon ).ContinueWith( task =>
 		{
 			var basePath = task.Result;
-			if (string.IsNullOrEmpty(basePath))
+			if ( string.IsNullOrEmpty( basePath ) )
 				return;
 
-			Log.Info($"Fetched {basePath}");
+			Log.Info( $"Fetched {basePath}" );
 
 			var color = Parent?.ComputedStyle?.FontColor?.Hex ?? "#ffffff";
 			var width = Box.Rect.Width;
@@ -144,7 +144,7 @@ public class IconifyPanel : Panel
 			var pathParams = $"?color={color}&w={width}&h={height}";
 
 			var path = basePath + pathParams;
-			_svgTexture = Texture.Load(FileSystem.Data, path);
-		});
+			_svgTexture = Texture.Load( FileSystem.Data, path );
+		} );
 	}
 }

--- a/IconifyPanel.cs
+++ b/IconifyPanel.cs
@@ -129,6 +129,9 @@ public class IconifyPanel : Panel
 		FetchIconAsync(Icon).ContinueWith(task =>
 		{
 			var basePath = task.Result;
+			if (string.IsNullOrEmpty(basePath))
+                return;
+
 			Log.Info($"Fetched {basePath}");
 
 			var color = Parent?.ComputedStyle?.FontColor?.Hex ?? "#ffffff";

--- a/IconifyPanel.cs
+++ b/IconifyPanel.cs
@@ -124,6 +124,7 @@ public class IconifyPanel : Panel
 		if (!_dirty)
 			return;
 
+		_dirty = false;
 		_svgTexture = Texture.White;
 
 		FetchIconAsync(Icon).ContinueWith(task =>
@@ -141,8 +142,6 @@ public class IconifyPanel : Panel
 
 			var path = basePath + pathParams;
 			_svgTexture = Texture.Load(FileSystem.Data, path);
-
-			_dirty = false;
 		});
 	}
 }


### PR DESCRIPTION
This PR fixes a few small issues with the library.

1. Bail from SetIcon when receiving a 404 in the iconify API. This prevents loading an invalid texture later on.
2. Reset the _dirty bool at the start of SetIcon. This prevents the method from being called multiple times before it resets at the end of the method.
3. Avoid editing the _icon and _dirty fields when passing the current value to Icon. Prevents a useless call to SetIcon.
4. Added the default S&box editor config and formatted.