### PR TITLE
FileSystem cache changes

### DIFF
--- a/IconifyIcon.cs
+++ b/IconifyIcon.cs
@@ -14,7 +14,7 @@ public struct IconifyIcon
 	public bool IsTintable { get; private set; }
 
 	private readonly string Url => $"https://api.iconify.design/{Prefix}/{Name}.svg";
-	private readonly string LocalPath => $"iconify/{Prefix}/{Name}.svg";
+	private readonly string LocalPath => $"{Prefix}/{Name}.svg";
 
 	private async Task<string> FetchImageDataAsync()
 	{

--- a/IconifyIcon.cs
+++ b/IconifyIcon.cs
@@ -56,7 +56,7 @@ public struct IconifyIcon
 		await EnsureIconDataIsCachedAsync();
 
 		// HACK: Check whether this icon is tintable based on whether it references CSS currentColor
-		var imageData = FileSystem.Data.ReadAllText( LocalPath );
+		var imageData = await FileSystem.Data.ReadAllTextAsync( LocalPath );
 		IsTintable = imageData.Contains( "currentColor" );
 
 		var pathParams = BuildPathParams( rect, tintColor );

--- a/IconifyIcon.cs
+++ b/IconifyIcon.cs
@@ -37,33 +37,33 @@ public struct IconifyIcon
 		return content.Replace( " width=\"1em\" height=\"1em\"", "" );
 	}
 
-	public async Task EnsureIconDataIsCachedAsync()
+	public async Task EnsureIconDataIsCachedAsync( BaseFileSystem fs )
 	{
-		if ( !FileSystem.Data.FileExists( LocalPath ) )
+		if ( !fs.FileExists( LocalPath ) )
 		{
 			Log.Info( $"Cache miss for icon '{this}', fetching from API..." );
 
 			var directory = Path.GetDirectoryName( LocalPath );
-			FileSystem.Data.CreateDirectory( directory );
+			fs.CreateDirectory( directory );
 
 			var iconContents = await FetchImageDataAsync();
-			FileSystem.Data.WriteAllText( LocalPath, iconContents );
+			fs.WriteAllText( LocalPath, iconContents );
 		}
 	}
 
-	public async Task<Texture> LoadTextureAsync( Rect rect, Color? tintColor )
+	public async Task<Texture> LoadTextureAsync( BaseFileSystem fs, Rect rect, Color? tintColor )
 	{
-		await EnsureIconDataIsCachedAsync();
+		await EnsureIconDataIsCachedAsync( fs );
 
 		// HACK: Check whether this icon is tintable based on whether it references CSS currentColor
-		var imageData = await FileSystem.Data.ReadAllTextAsync( LocalPath );
+		var imageData = await fs.ReadAllTextAsync( LocalPath );
 		IsTintable = imageData.Contains( "currentColor" );
 
 		var pathParams = BuildPathParams( rect, tintColor );
 		var path = LocalPath + pathParams;
 
 		Log.Info( $"Fetching {path}" );
-		return Texture.Load( FileSystem.Data, path );
+		return Texture.Load( fs, path );
 	}
 
 	private string BuildPathParams( Rect rect, Color? tintColor )

--- a/IconifyIcon.cs
+++ b/IconifyIcon.cs
@@ -79,7 +79,7 @@ public struct IconifyIcon
 		pathParamsBuilder.Append( $"w={width}&h={height}" );
 		return pathParamsBuilder.ToString();
 	}
-	
+
 	public IconifyIcon( string path )
 	{
 		if ( !path.Contains( ':' ) )

--- a/IconifyIcon.cs
+++ b/IconifyIcon.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Iconify;
+using System;
 using System.IO;
 using System.Net;
 using System.Text;
@@ -47,8 +48,9 @@ public struct IconifyIcon
 		}
 	}
 
-	public async Task<Texture> LoadTextureAsync( BaseFileSystem fs, Rect rect, Color? tintColor )
+	public async Task<Texture> LoadTextureAsync( Rect rect, Color? tintColor )
 	{
+		var fs = IconifyOptions.Current.CacheFileSystem;
 		await EnsureIconDataIsCachedAsync( fs );
 
 		// HACK: Check whether this icon is tintable based on whether it references CSS currentColor

--- a/IconifyOptions.cs
+++ b/IconifyOptions.cs
@@ -1,0 +1,40 @@
+﻿using Sandbox;
+
+namespace Iconify;
+
+/// <summary>
+/// Contains all configurable options in the Iconify library.
+/// </summary>
+public class IconifyOptions
+{
+	/// <summary>
+	/// The instance of <see cref="IconifyOptions"/> that the library will use.
+	/// </summary>
+	public static IconifyOptions Current { get; set; }
+
+	/// <summary>
+	/// The file system that cached icons will be written to. 
+	/// </summary>
+	public BaseFileSystem CacheFileSystem { get; set; } = FileSystem.Data;
+
+	static IconifyOptions()
+	{
+		if ( FileSystem.Data is null )
+			return;
+
+		FileSystem.Data.CreateDirectory( "iconify" );
+		Current = new IconifyOptions()
+			.WithCacheFileSystem( FileSystem.Data.CreateSubSystem( "iconify" ) );
+	}
+
+	/// <summary>
+	/// Sets the <see cref="CacheFileSystem"/> property.
+	/// </summary>
+	/// <param name="fs">The file system that cached icons will be written to.</param>
+	/// <returns>The same instance of <see cref="IconifyOptions"/>.</returns>
+	public IconifyOptions WithCacheFileSystem( BaseFileSystem fs )
+	{
+		CacheFileSystem = fs;
+		return this;
+	}
+}

--- a/IconifyPanel.cs
+++ b/IconifyPanel.cs
@@ -5,6 +5,9 @@ namespace Sandbox.UI;
 [Alias( "iconify", "iconify-icon" )]
 public class IconifyPanel : Panel
 {
+	public static readonly BaseFileSystem DefaultCache = FileSystem.Data;
+
+	private readonly BaseFileSystem cacheFs;
 	private Texture _svgTexture;
 
 	private bool _dirty = false;
@@ -23,8 +26,14 @@ public class IconifyPanel : Panel
 		}
 	}
 
-	public IconifyPanel()
+	public IconifyPanel() : this( DefaultCache )
 	{
+	}
+
+	public IconifyPanel( BaseFileSystem cacheFs )
+	{
+		this.cacheFs = cacheFs;
+
 		StyleSheet.Parse( """
 		IconifyPanel, iconify, iconify-icon {
 			height: 16px;
@@ -83,7 +92,7 @@ public class IconifyPanel : Panel
 		var rect = Box.Rect;
 		var tintColor = Parent?.ComputedStyle?.FontColor?.Hex;
 		
-		icon.LoadTextureAsync( rect, tintColor ).ContinueWith( ( task ) =>
+		icon.LoadTextureAsync( cacheFs, rect, tintColor ).ContinueWith( ( task ) =>
 		{
 			_svgTexture = task.Result;
 		} );

--- a/IconifyPanel.cs
+++ b/IconifyPanel.cs
@@ -12,8 +12,6 @@ public class IconifyPanel : Panel
 	private bool _dirty = false;
 	private string _icon = "";
 
-	public BaseFileSystem CacheFileSystem { get; set; }
-
 	public string Icon
 	{
 		get => _icon;
@@ -36,14 +34,8 @@ public class IconifyPanel : Panel
 		DefaultCache = FileSystem.Data.CreateSubSystem( "iconify" );
 	}
 
-	public IconifyPanel() : this( DefaultCache )
+	public IconifyPanel()
 	{
-	}
-
-	public IconifyPanel( BaseFileSystem cacheFs )
-	{
-		CacheFileSystem = cacheFs;
-
 		StyleSheet.Parse( """
 		IconifyPanel, iconify, iconify-icon {
 			height: 16px;
@@ -80,21 +72,6 @@ public class IconifyPanel : Panel
 			Icon = value;
 	}
 
-	public override void SetPropertyObject( string name, object value )
-	{
-		base.SetPropertyObject( name, value );
-
-		if ( !name.Equals( "cache", StringComparison.OrdinalIgnoreCase ) &&
-			!name.Equals( "cachefs", StringComparison.OrdinalIgnoreCase ) &&
-			!name.Equals( "cachefilesystem", StringComparison.OrdinalIgnoreCase ) )
-			return;
-
-		if ( value is not BaseFileSystem fs )
-			throw new ArgumentException( $"Did not receive a {nameof( BaseFileSystem )} value to cache property", nameof( value ) );
-
-		CacheFileSystem = fs;
-	}
-
 	public override void DrawBackground( ref RenderState state )
 	{
 		base.DrawBackground( ref state );
@@ -117,7 +94,7 @@ public class IconifyPanel : Panel
 		var rect = Box.Rect;
 		var tintColor = ComputedStyle?.FontColor;
 		
-		icon.LoadTextureAsync( CacheFileSystem, rect, tintColor ).ContinueWith( ( task ) =>
+		icon.LoadTextureAsync( rect, tintColor ).ContinueWith( ( task ) =>
 		{
 			_svgTexture = task.Result;
 		} );

--- a/IconifyPanel.cs
+++ b/IconifyPanel.cs
@@ -117,7 +117,7 @@ public class IconifyPanel : Panel
 		var rect = Box.Rect;
 		var tintColor = ComputedStyle?.FontColor;
 		
-		icon.LoadTextureAsync( cacheFs, rect, tintColor ).ContinueWith( ( task ) =>
+		icon.LoadTextureAsync( CacheFileSystem, rect, tintColor ).ContinueWith( ( task ) =>
 		{
 			_svgTexture = task.Result;
 		} );

--- a/IconifyPanel.cs
+++ b/IconifyPanel.cs
@@ -7,11 +7,12 @@ public class IconifyPanel : Panel
 {
 	public static readonly BaseFileSystem DefaultCache;
 
-	private readonly BaseFileSystem cacheFs;
 	private Texture _svgTexture;
 
 	private bool _dirty = false;
 	private string _icon = "";
+
+	public BaseFileSystem CacheFileSystem { get; set; }
 
 	public string Icon
 	{
@@ -41,7 +42,7 @@ public class IconifyPanel : Panel
 
 	public IconifyPanel( BaseFileSystem cacheFs )
 	{
-		this.cacheFs = cacheFs;
+		CacheFileSystem = cacheFs;
 
 		StyleSheet.Parse( """
 		IconifyPanel, iconify, iconify-icon {
@@ -74,9 +75,24 @@ public class IconifyPanel : Panel
 	public override void SetProperty( string name, string value )
 	{
 		base.SetProperty( name, value );
-		
+
 		if ( name.Equals( "icon", StringComparison.OrdinalIgnoreCase ) || name.Equals( "name", StringComparison.OrdinalIgnoreCase ) )
 			Icon = value;
+	}
+
+	public override void SetPropertyObject( string name, object value )
+	{
+		base.SetPropertyObject( name, value );
+
+		if ( !name.Equals( "cache", StringComparison.OrdinalIgnoreCase ) &&
+			!name.Equals( "cachefs", StringComparison.OrdinalIgnoreCase ) &&
+			!name.Equals( "cachefilesystem", StringComparison.OrdinalIgnoreCase ) )
+			return;
+
+		if ( value is not BaseFileSystem fs )
+			throw new ArgumentException( $"Did not receive a {nameof( BaseFileSystem )} value to cache property", nameof( value ) );
+
+		CacheFileSystem = fs;
 	}
 
 	public override void DrawBackground( ref RenderState state )
@@ -88,7 +104,7 @@ public class IconifyPanel : Panel
 		Graphics.Attributes.SetCombo( "D_BLENDMODE", BlendMode.Normal );
 		Graphics.DrawQuad( Box.Rect, Material.UI.Basic, Color.White );
 	}
-	
+
 	private void SetIcon()
 	{
 		if ( !_dirty )

--- a/IconifyPanel.cs
+++ b/IconifyPanel.cs
@@ -5,7 +5,7 @@ namespace Sandbox.UI;
 [Alias( "iconify", "iconify-icon" )]
 public class IconifyPanel : Panel
 {
-	public static readonly BaseFileSystem DefaultCache = FileSystem.Data;
+	public static readonly BaseFileSystem DefaultCache;
 
 	private readonly BaseFileSystem cacheFs;
 	private Texture _svgTexture;
@@ -24,6 +24,15 @@ public class IconifyPanel : Panel
 			_icon = value;
 			_dirty = true;
 		}
+	}
+
+	static IconifyPanel()
+	{
+		if ( FileSystem.Data is null )
+			return;
+
+		FileSystem.Data.CreateDirectory( "iconify" );
+		DefaultCache = FileSystem.Data.CreateSubSystem( "iconify" );
 	}
 
 	public IconifyPanel() : this( DefaultCache )


### PR DESCRIPTION
This PR makes a couple of changes when interacting with the icon cache while maintaining backward compatibility.

1. Uses async IO operations where available instead of blocking ones.
2. Allows the user to change the file system used for caching icons.
  * Can be set in code or in Razor.
  * Defaults to the iconify directory in FileSystem.Data as was default before.
  * The cache is written to the root directory of the file system provided.

### Known Issues
As mentioned in a4264d97387dd9addd77835900988ff9b1c78df1 S&box doesn't seem to call SetPropertyObject and instead ToStrings everything and passes it through SetProperty instead. Because of this you cannot actually set the cache in Razor right now.